### PR TITLE
Plotter: add control on how to resolve the axes origin label drawing and possibility to override axes text stroke

### DIFF
--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -208,7 +208,7 @@ pub struct Plot {
     coordinates_formatter: Option<(Corner, CoordinatesFormatter)>,
     axis_formatters: [AxisFormatter; 2],
     x_axis_origin_label_has_priority: bool,
-    axes_text_stroke_override: [Option<Stroke>; 2],
+    axes_text_stroke_overrides: [Option<Stroke>; 2],
     legend_config: Option<Legend>,
     show_background: bool,
     show_axes: [bool; 2],
@@ -252,7 +252,7 @@ impl Plot {
             coordinates_formatter: None,
             axis_formatters: [None, None], // [None; 2] requires Copy
             x_axis_origin_label_has_priority: true,
-            axes_text_stroke_override: [None, None],
+            axes_text_stroke_overrides: [None, None],
             legend_config: None,
             show_background: true,
             show_axes: [true; 2],
@@ -460,7 +460,7 @@ impl Plot {
     /// Instead of calculating the color of the stroke using the spacing calculations, always use the color provided in the stroke.
     /// The `width` field is used as a replacement for the `Shape`'s strength, which is used to determine which shape is drawn on top.
     pub fn x_axis_text_stroke_override(mut self, stroke: Stroke) -> Self {
-        self.axes_text_stroke_override[0] = Some(stroke);
+        self.axes_text_stroke_overrides[0] = Some(stroke);
         self
     }
 
@@ -468,7 +468,7 @@ impl Plot {
     /// Instead of calculating the color of the stroke using the spacing calculations, always use the color provided in the stroke.
     /// The `width` field is used as a replacement for the `Shape`'s strength, which is used to determine which shape is drawn on top.
     pub fn y_axis_text_stroke_override(mut self, stroke: Stroke) -> Self {
-        self.axes_text_stroke_override[1] = Some(stroke);
+        self.axes_text_stroke_overrides[1] = Some(stroke);
         self
     }
 
@@ -644,7 +644,7 @@ impl Plot {
             coordinates_formatter,
             axis_formatters,
             x_axis_origin_label_has_priority,
-            axes_text_stroke_override,
+            axes_text_stroke_overrides,
             legend_config,
             reset,
             show_background,
@@ -998,7 +998,7 @@ impl Plot {
             clamp_grid,
 
             x_axis_origin_label_has_priority,
-            axes_text_stroke_override,
+            axes_text_stroke_overrides,
         };
         let plot_cursors = prepared.ui(ui, &response);
 
@@ -1364,7 +1364,7 @@ struct PreparedPlot {
     clamp_grid: bool,
 
     x_axis_origin_label_has_priority: bool,
-    axes_text_stroke_override: [Option<Stroke>; 2],
+    axes_text_stroke_overrides: [Option<Stroke>; 2],
 }
 
 impl PreparedPlot {
@@ -1565,7 +1565,8 @@ impl PreparedPlot {
 
             const MIN_TEXT_SPACING: f32 = 40.0;
             if spacing_in_points > MIN_TEXT_SPACING {
-                let (strength, color) = if let Some(stroke) = self.axes_text_stroke_override[axis] {
+                let (strength, color) = if let Some(stroke) = self.axes_text_stroke_overrides[axis]
+                {
                     // bit of a hack...
                     (stroke.width, stroke.color)
                 } else {
@@ -1582,7 +1583,11 @@ impl PreparedPlot {
                 };
 
                 // Skip origin label for the axis that doesn't have priority, if the axis with priority is already showing it (otherwise it's displayed twice)
-                let priority_axis_idx = !self.x_axis_origin_label_has_priority as usize;
+                let priority_axis_idx = if self.x_axis_origin_label_has_priority {
+                    0
+                } else {
+                    1
+                };
                 let skip_low_priority_origin =
                     axis != priority_axis_idx && other_axis_shown && value_main == 0.0;
 

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -1566,6 +1566,7 @@ impl PreparedPlot {
             const MIN_TEXT_SPACING: f32 = 40.0;
             if spacing_in_points > MIN_TEXT_SPACING {
                 let (strength, color) = if let Some(stroke) = self.axes_text_stroke_override[axis] {
+                    // bit of a hack...
                     (stroke.width, stroke.color)
                 } else {
                     let text_strength =

--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -458,7 +458,7 @@ impl Plot {
 
     /// Overrides the default behaviour of the X axis' text rendering.
     /// Instead of calculating the color of the stroke using the spacing calculations, always use the color provided in the stroke.
-    /// The `width` field is used as a replacement for the `Shape`'s strenght, which is used to determine which shape is drawn on top.
+    /// The `width` field is used as a replacement for the `Shape`'s strength, which is used to determine which shape is drawn on top.
     pub fn x_axis_text_stroke_override(mut self, stroke: Stroke) -> Self {
         self.axes_text_stroke_override[0] = Some(stroke);
         self
@@ -466,7 +466,7 @@ impl Plot {
 
     /// Overrides the default behaviour of the X axis' text rendering.
     /// Instead of calculating the color of the stroke using the spacing calculations, always use the color provided in the stroke.
-    /// The `width` field is used as a replacement for the `Shape`'s strenght, which is used to determine which shape is drawn on top.
+    /// The `width` field is used as a replacement for the `Shape`'s strength, which is used to determine which shape is drawn on top.
     pub fn y_axis_text_stroke_override(mut self, stroke: Stroke) -> Self {
         self.axes_text_stroke_override[1] = Some(stroke);
         self

--- a/crates/egui_extras/src/table.rs
+++ b/crates/egui_extras/src/table.rs
@@ -542,7 +542,7 @@ pub struct Table<'a> {
 
 /// Returned from [`Table::body`]. Contains information about the way the table has been built by the context.
 pub struct TableOutput {
-    /// The response recieved upon the creation of the table's header, if one was defined.
+    /// The response received upon the creation of the table's header, if one was defined.
     pub header_response: Option<Response>,
 
     /// The output of the [`ScrollArea`] containing the table body's contents.


### PR DESCRIPTION
A bit of a mess-PR, but would like to gather some feedback/suggestions on it.
This PR tackles two issues, which I'll discuss below:

### Origin labels conflict

When developing an horizontal stackable bars graph to be used as a budget tracker, I wanted to be able to always display the Y-axis labels, but the origin label was **always** showing only for the X-axis due to the following code

```rust
        // Skip origin label for y-axis if x-axis is already showing it (otherwise displayed twice)
        let skip_origin_y = axis == 1 && other_axis_shown && value_main == 0.0;
```

I opted for giving the user control on how this "clash" is resolved through a `x_axis_origin_label_has_priority` bool. The name is not the greatest I'd say, but it kind-of explains what it's doing. Suggestions for another name and/or how to tackle this problem differently if there's a preferred solution are appreciated.

### Automated text color

The plotter automatically handles the color of the axes text labels based on the defined spacing. This allows the plotter to highlight -in example- the decimals and showcase the floating numbers in between in a lower contrast. 
It also calculates all of the necessary colors from the `ui.visuals()`, which means we can't -in example- decide to show the labels in red unless we change the style of the entire UI.

```rust
        fn color_from_contrast(ui: &Ui, contrast: f32) -> Color32 {
            let bg = ui.visuals().extreme_bg_color;
            let fg = ui.visuals().widgets.open.fg_stroke.color;
            let mix = 0.5 * contrast.sqrt();
            Color32::from_rgb(
                lerp((bg.r() as f32)..=(fg.r() as f32), mix) as u8,
                lerp((bg.g() as f32)..=(fg.g() as f32), mix) as u8,
                lerp((bg.b() as f32)..=(fg.b() as f32), mix) as u8,
            )
        }
```

```rust
        let text_strength = remap_clamp(spacing_in_points, MIN_TEXT_SPACING..=150.0, 0.0..=1.0);
        let color = color_from_contrast(ui, text_strength);
```

Note that `text_strength` here is just a value that the plotter uses to resolve "who drows on top of whom" based on this strength number. It doesn't actually changes the stroke of the text.

To work around this limitation, I added an `axes_text_stroke_override` field to allow the user to provide a fixed Color and `text_stength` for the axes, through re-using the existing `Stroke` struct and using the stroke width to control which axis draws on top.
This is the hackiest of the changes, but it allowed me to get the job done quickly 😄 
Again -and even more- for this, suggestions are appreciated on how to tackle this better.
