### PR TITLE
Add `Slider::thickness`

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -90,6 +90,7 @@ pub struct Slider<'a> {
     handle_shape: Option<HandleShape>,
 
     rail_color: Option<Color32>,
+    thickness: Option<f32>,
 }
 
 impl<'a> Slider<'a> {
@@ -139,6 +140,7 @@ impl<'a> Slider<'a> {
             handle_shape: None,
 
             rail_color: None,
+            thickness: None,
         }
     }
 
@@ -529,6 +531,13 @@ impl<'a> Slider<'a> {
         self
     }
 
+    /// Override slider thickness.
+    #[inline]
+    pub fn thickness(mut self, thickness: f32) -> Self {
+        self.thickness = Some(thickness);
+        self
+    }
+
     fn get_value(&mut self) -> f64 {
         let value = get(&mut self.get_set_value);
         if self.clamp_to_range {
@@ -865,9 +874,10 @@ impl<'a> Slider<'a> {
     fn add_contents(&mut self, ui: &mut Ui) -> Response {
         let old_value = self.get_value();
 
-        let thickness = ui
-            .text_style_height(&TextStyle::Body)
-            .at_least(ui.spacing().interact_size.y);
+        let thickness = self.thickness.unwrap_or_else(|| {
+            ui.text_style_height(&TextStyle::Body)
+                .at_least(ui.spacing().interact_size.y)
+        });
         let mut response = self.allocate_slider_space(ui, thickness);
         self.slider_ui(ui, &response);
 


### PR DESCRIPTION
In evolve we currently have a alignment issue with the slider widget. The problem is that the value button isn't properly center aligned with the slider. More specifically, the slider implementation calls `ui.horizontal` which internally sets the height of the UI to `interact_size.y` which in turn effects the alignment of widgets. 

In evolve, in order to work around this we set the `interact_size.y` to a desired size which will result in the value button being properly center aligned with the slider. The issue with this is that the `interact_size.y` is also used for the thickness of the slider, which is something we do not want to change. 

This PR "fixes" this problem by exposing a `thickness` override. As a result, we can use `interact_size.y` to set the correct height of the slider UI and use the thickness override to use the right slider thickness.

There is probably a better way of fixing this but I have no idea what that would look like. The current change required the least amount of work without it effecting how sliders are drawn in general.
