### PR TITLE
Extend `Slider` with `symmetric_slider` bool which allows trailing fill to extend from the 0th point to the handle

### DIFF
--- a/crates/egui/src/widgets/slider.rs
+++ b/crates/egui/src/widgets/slider.rs
@@ -91,6 +91,8 @@ pub struct Slider<'a> {
 
     rail_color: Option<Color32>,
     thickness: Option<f32>,
+
+    symmetric_slider: bool,
 }
 
 impl<'a> Slider<'a> {
@@ -103,6 +105,26 @@ impl<'a> Slider<'a> {
             }
             value.to_f64()
         });
+
+        if Num::INTEGRAL {
+            slf.integer()
+        } else {
+            slf
+        }
+    }
+
+    /// Creates a new horizontal slider with symmetric values.
+    pub fn new_symmetric<Num: emath::Numeric>(value: &'a mut Num, max_abs_value: Num) -> Self {
+        let abs_value = max_abs_value.to_f64().abs();
+        let range_f64 = -abs_value..=abs_value;
+        let mut slf = Self::from_get_set(range_f64, move |v: Option<f64>| {
+            if let Some(v) = v {
+                *value = Num::from_f64(v);
+            }
+            value.to_f64()
+        });
+
+        slf.symmetric_slider = true;
 
         if Num::INTEGRAL {
             slf.integer()
@@ -141,6 +163,8 @@ impl<'a> Slider<'a> {
 
             rail_color: None,
             thickness: None,
+
+            symmetric_slider: false,
         }
     }
 
@@ -725,10 +749,36 @@ impl<'a> Slider<'a> {
                 let mut trailing_rail_rect = rail_rect;
 
                 // The trailing rect has to be drawn differently depending on the orientation.
-                match self.orientation {
-                    SliderOrientation::Vertical => trailing_rail_rect.min.y = center.y,
-                    SliderOrientation::Horizontal => trailing_rail_rect.max.x = center.x,
-                };
+                if self.symmetric_slider {
+                    let position_at_0 = self.position_from_value(0.0, position_range);
+                    let center_at_0 = self.marker_center(position_at_0, &rail_rect);
+
+                    match self.orientation {
+                        SliderOrientation::Vertical => {
+                            if center.y < center_at_0.y {
+                                trailing_rail_rect.min.y = center.y;
+                                trailing_rail_rect.max.y = center_at_0.y;
+                            } else {
+                                trailing_rail_rect.min.y = center_at_0.y;
+                                trailing_rail_rect.max.y = center.y;
+                            }
+                        }
+                        SliderOrientation::Horizontal => {
+                            if center.x < center_at_0.x {
+                                trailing_rail_rect.min.x = center.x;
+                                trailing_rail_rect.max.x = center_at_0.x;
+                            } else {
+                                trailing_rail_rect.min.x = center_at_0.x;
+                                trailing_rail_rect.max.x = center.x;
+                            }
+                        }
+                    };
+                } else {
+                    match self.orientation {
+                        SliderOrientation::Vertical => trailing_rail_rect.min.y = center.y,
+                        SliderOrientation::Horizontal => trailing_rail_rect.max.x = center.x,
+                    };
+                }
 
                 ui.painter().rect_filled(
                     trailing_rail_rect,

--- a/crates/egui_demo_lib/src/demo/widget_gallery.rs
+++ b/crates/egui_demo_lib/src/demo/widget_gallery.rs
@@ -15,6 +15,7 @@ pub struct WidgetGallery {
     opacity: f32,
     radio: Enum,
     scalar: f32,
+    symmetric_value: f32,
     string: String,
     color: egui::Color32,
     animate_progress_bar: bool,
@@ -33,6 +34,7 @@ impl Default for WidgetGallery {
             boolean: false,
             radio: Enum::First,
             scalar: 42.0,
+            symmetric_value: 0.0,
             string: Default::default(),
             color: egui::Color32::LIGHT_BLUE.linear_multiply(0.5),
             animate_progress_bar: false,
@@ -112,6 +114,7 @@ impl WidgetGallery {
             boolean,
             radio,
             scalar,
+            symmetric_value,
             string,
             color,
             animate_progress_bar,
@@ -181,7 +184,19 @@ impl WidgetGallery {
         ui.end_row();
 
         ui.add(doc_link_label("Slider", "Slider"));
-        ui.add(egui::Slider::new(scalar, 0.0..=360.0).suffix("°"));
+        ui.add(
+            egui::Slider::new(scalar, 0.0..=360.0)
+                .suffix("°")
+                .trailing_fill(true),
+        );
+        ui.end_row();
+
+        ui.add(doc_link_label("Symmetric Slider", "Slider"));
+        ui.add(
+            egui::Slider::new_symmetric(symmetric_value, 90.0)
+                .suffix("°")
+                .trailing_fill(true),
+        );
         ui.end_row();
 
         ui.add(doc_link_label("DragValue", "DragValue"));


### PR DESCRIPTION
As per the title. 
A `new_symmetric` constructor is added that takes a single value rather than a range.

![image](https://github.com/user-attachments/assets/2eb523f3-e885-4927-9b06-41f470c61ee5)

![image](https://github.com/user-attachments/assets/17f3b77a-8076-49be-8afd-1d9a3bbb81d6)

